### PR TITLE
Remove unused adventure option

### DIFF
--- a/Fuggin_Figgghhhhhhtttt.py
+++ b/Fuggin_Figgghhhhhhtttt.py
@@ -1252,21 +1252,12 @@ def Main_Menu(  ):
         print( "|                                               |" )
         print( "|  Hey Feller! Where would you like to go...    |" )
         print( "|                                               |" )
-        print( "|      a = adventure                            |" )
         print( "|      f = fight                                |" )
         print( "|      e = exit                                 |" )
         print( "|                                               |" )
     #    print( "    s = settings" ) # Edits a JSON FILE
         Game = input( "| :" )
-        if( Game == "a" ):
-
-            print( "\\_______________________________________________/" )
-            print(  )
-            print(  )
-            Adventure(  )
-            print( "  ______________________________________________" )
-            print( " /                                              \\ " )
-        elif( Game == "f" ):
+        if( Game == "f" ):
 
             print( "\\_______________________________________________/" )
             print(  )
@@ -1287,7 +1278,7 @@ def Main_Menu(  ):
                 print( "| | !!! Please try again...         !!! |       |" )
                 
             elif( err_cnt == 2 ):
-                print( "| | !!! It's only like 3 things...  !!! |       |")
+                print( "| | !!! It's only like 2 things...  !!! |       |")
                 print( "| | !!! It's not very hard...       !!! |       |" )
                 print( "| | !!! Try again...                !!! |       |" )
             elif( err_cnt == 3 ):


### PR DESCRIPTION
## Summary
- remove `adventure` choice from `Main_Menu`
- update error message to reflect only two options

## Testing
- `python3 -m py_compile Fuggin_Figgghhhhhhtttt.py`

------
https://chatgpt.com/codex/tasks/task_e_68435ee5270483208b2315bcc272e3d8